### PR TITLE
Holographic Camera should be child of Player not UNetAnchorManager

### DIFF
--- a/SpectatorView/Samples/SharedHolograms/Assets/Addons/HolographicCameraRig/SV_UNET/Scripts/PlayerController.cs
+++ b/SpectatorView/Samples/SharedHolograms/Assets/Addons/HolographicCameraRig/SV_UNET/Scripts/PlayerController.cs
@@ -389,7 +389,7 @@ namespace SpectatorView
                 !SpectatorView.SpectatorViewManager.Instance.IsCurrentlyActive &&
                 IsSV())
             {
-                SpectatorView.SpectatorViewManager.Instance.EnableHolographicCamera(UNetAnchorManager.Instance.gameObject.transform);
+                SpectatorView.SpectatorViewManager.Instance.EnableHolographicCamera(this.gameObject.transform);
             }
 #endif
         }


### PR DESCRIPTION
Without this, when the SpectatorView HoloLens comes online, the Holographic camera does not follow the remoted pose defeating the whole purpose of SpectatorView.

With this change, the correct calibration is also used...