### PR TITLE
fix race condition when updating connection address

### DIFF
--- a/HoloLensCommander/HoloLensCommander/Controls/DeviceMonitorControlViewModel.cs
+++ b/HoloLensCommander/HoloLensCommander/Controls/DeviceMonitorControlViewModel.cs
@@ -646,9 +646,16 @@ namespace HoloLensCommander
             // Was this the first time we received a heartbeat?
             if (!this.firstContact)
             {
+                // Update the device address display.
+                this.Address = this.deviceMonitor.Address;
+                ((DeviceMonitorControlViewModel)(this.deviceMonitorControl.DataContext)).Address = this.Address;
+
                 // Cause common apps to be refreshed.
                 this.deviceMonitorControl.NotifySelectedChanged();
                 this.firstContact = true;
+
+                // Re-save the collection...
+                this.deviceMonitorControl.NotifyTagChanged();
             }
 
             // Update the UI

--- a/HoloLensCommander/HoloLensCommander/HoloLensCommander.csproj
+++ b/HoloLensCommander/HoloLensCommander/HoloLensCommander.csproj
@@ -19,7 +19,7 @@
     <PackageCertificateKeyFile>HoloLensCommander_TemporaryKey.pfx</PackageCertificateKeyFile>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x86</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64</AppxBundlePlatforms>
     <PackageCertificateThumbprint>A4B49ABD7F86BC59443864123563E3BB0CCBC3A9</PackageCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/HoloLensCommander/HoloLensCommander/Package.appxmanifest
+++ b/HoloLensCommander/HoloLensCommander/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="HoloLensCommander" Publisher="CN=HoloLensCommander" Version="2.1706.0.0" />
+  <Identity Name="HoloLensCommander" Publisher="CN=HoloLensCommander" Version="2.1706.2.0" />
   <mp:PhoneIdentity PhoneProductId="2ddfe2f3-79a6-4751-9a5c-56c49317682a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Windows Mixed Reality Commander</DisplayName>

--- a/HoloLensCommander/HoloLensCommander/Properties/AssemblyInfo.cs
+++ b/HoloLensCommander/HoloLensCommander/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1706.0.0")]
-[assembly: AssemblyFileVersion("2.1706.0.0")]
+[assembly: AssemblyVersion("2.1706.1.0")]
+[assembly: AssemblyFileVersion("2.1706.1.0")]
 [assembly: ComVisible(false)]
 [assembly: NeutralResourcesLanguage("en-US")]
 


### PR DESCRIPTION
There was a race condition when connecting to a HoloLens via the USB loopback address, where we may miss the address change and display/store incorrect data. the connection to the Device Portal used the correct address, however.

The fix is the re-fetch the device address from the Device Portal on first contact (the first successful heartbeat), update the UI and then signal to the main window that it should re-save the connected devices list.

This closes #210 
