### PR TITLE
Add ReferenceCopyLocalPaths to csproj to find implementation dll for …

### DIFF
--- a/MixedRemoteViewCompositor/Samples/LowLatencyMRC/UWP/Viewer/Viewer.csproj
+++ b/MixedRemoteViewCompositor/Samples/LowLatencyMRC/UWP/Viewer/Viewer.csproj
@@ -95,10 +95,12 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="MixedRemoteViewCompositor, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)..\..\..\Build\$(Configuration)\Plugins\WSA\$(PlatformName)\MixedRemoteViewCompositor.winmd</HintPath>
+    <Reference Include="MixedRemoteViewCompositor">
+      <HintPath>..\..\..\..\Source\Win32\MixedRemoteViewCompositor.winmd</HintPath>      
+      <IsWinMDFile>true</IsWinMDFile>
+      <Implementation>MixedRemoteViewCompositor.dll</Implementation>
     </Reference>
+<ReferenceCopyLocalPaths Include="$(SolutionDir)..\..\..\Build\$(Configuration)\Plugins\WSA\$(PlatformName)\MixedRemoteViewCompositor.dll" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>


### PR DESCRIPTION
This should resolve the "implementation file not found" issue in #199 
Since the MixedRemoteViewCompositor reference is set CopyLocal=true, we can use the <ReferenceCopyLocalPaths> to point to the dll.

I believe we can also leave SpecificVersion=false out, since it looks like Visual Studio defaults to SpecificVersion=false if we don't have a version/culture on the reference.  