### PR TITLE
Fix dead link to get OpenCV

### DIFF
--- a/SpectatorView/Calibration/README.md
+++ b/SpectatorView/Calibration/README.md
@@ -14,7 +14,7 @@ Open the Calibration sln with Visual Studio under Calibration\Calibration.sln
 ![compositor sln](../DocumentationImages/calibration_sln.png)
 
 ### OpenCV 3.2
-+ Download and install OpenCV 3.2 from here: http://opencv.org/downloads.html
++ Download and install OpenCV 3.2 from here: http://opencv.org/releases.html
 + Extract OpenCV anywhere on your computer.
 + Update the OpenCV_vc14 user macro in dependencies.props with the corresponding path on your computer.
 + Restart Visual Studio if the Calibration or Compositor sln's are open.

--- a/SpectatorView/Compositor/README.md
+++ b/SpectatorView/Compositor/README.md
@@ -21,7 +21,7 @@ If you are using a Blackmagic capture card, you will need to install the SDK and
 
 ### OpenCV 3.2
 If you are not using a capture card with an included FrameProvider, you will need to install Open CV to get color frames from a different capture device.
-+ Download and install OpenCV 3.2 from here: http://opencv.org/downloads.html
++ Download and install OpenCV 3.2 from here: https://opencv.org/releases.html
 + Extract OpenCV anywhere on your computer.
 + Update the OpenCV_vc14 user macro in dependencies.props with the corresponding path on your computer.
 + Restart Visual Studio if the Calibration or Compositor sln's are open.

--- a/SpectatorView/README.md
+++ b/SpectatorView/README.md
@@ -70,7 +70,7 @@ The following dependencies require a manual download and a Visual Studio user ma
 ![Dependencies](./DocumentationImages/dependencies.png)
 
 ### OpenCV 3.2
-+ Download and install OpenCV **3.2** from [here](http://opencv.org/releases.html).
++ Download and install OpenCV **3.2** from [here](https://opencv.org/releases.html).
 + Extract OpenCV anywhere on your computer.
 + Update the OpenCV_vc14 user macro in dependencies.props with the corresponding path on your computer.
 + Restart Visual Studio if the Calibration or Compositor sln's are open.


### PR DESCRIPTION
The OpenCV website doesn't have a "downloads.html" page anymore. This page list the releases. The user can grab the windows package for any version he likes.

I prefer linking that page on the OpenCV website rather than a direct download link out of SourceForge. I can edit the PR accordingly if you prefer that.