### PR TITLE
fix critical section initialization to avoid access violation

### DIFF
--- a/SpectatorView/Calibration/Calibration/CalibrationApp.cpp
+++ b/SpectatorView/Calibration/Calibration/CalibrationApp.cpp
@@ -20,6 +20,7 @@ CalibrationApp::CalibrationApp() :
     InitializeCriticalSection(&commandCriticalSection);
     InitializeCriticalSection(&calibrationPictureCriticalSection);
     InitializeCriticalSection(&chessBoardVisualCriticalSection);
+    InitializeCriticalSection(&photoVisualsCriticalSection);
 
     boardDimensions = cv::Size(GRID_CELLS_X - 1, GRID_CELLS_Y - 1);
     colorBytes = new BYTE[FRAME_BUFSIZE];


### PR DESCRIPTION
A critical section initialization got dropped in some work a while ago to improve the calibration ux experience