### PR TITLE
#337: Preventing Unity from crashing when webcam resolution does not match server's output width/height

### DIFF
--- a/RealtimeStreaming/Samples/Unity/Assets/Example/Scripts/WebcamServerSource.cs
+++ b/RealtimeStreaming/Samples/Unity/Assets/Example/Scripts/WebcamServerSource.cs
@@ -60,6 +60,14 @@ public class WebcamServerSource : RealtimeServerSource
 
         UnityEngine.Debug.Log("Webcam Playing at " + webcam.width + " x " + webcam.height);
 
+        if (webcam.width != Server.OutputWidth || webcam.height != Server.OutputHeight)
+        {
+            UnityEngine.Debug.LogWarning("Requested webcam resolution (" + webcam.width + " x " + webcam.height + ") does not match server output " + "(" + Server.OutputWidth + " x " + Server.OutputHeight + ")");
+            UnityEngine.Debug.LogWarning("Updating server to match it...");
+            Server.OutputWidth = (uint)webcam.width;
+            Server.OutputHeight = (uint)webcam.height;
+        }
+
         webcam_interop = new Color32[webcam.width * webcam.height];
         frameBuffer = new byte[webcam.width * webcam.height * 4];
 


### PR DESCRIPTION
This pull request fixes WebcamServerSource.cs so that it updates the server when the requested camera resolution is not the actual camera resolution. (Issue #337)